### PR TITLE
Update Translations.php

### DIFF
--- a/formwidgets/Translations.php
+++ b/formwidgets/Translations.php
@@ -127,7 +127,7 @@ class Translations extends FormWidgetBase
                 }
 
                 $fieldObj->displayAs($fieldType, $field_config);
-                $fieldObj->value = $this->model->getTranslateAttribute($fieldObj->fieldName, $locale);
+                $fieldObj->value = $this->model->getAttributeTranslated($fieldObj->fieldName, $locale);
 
                 $fields[] = $fieldObj;
             }
@@ -176,7 +176,7 @@ class Translations extends FormWidgetBase
             return $widget->makePartial('codeeditor');
         } else {
             $field->displayAs($options['type']);
-            $field->value = $this->model->getTranslateAttribute($fieldName, $locale);
+            $field->value = $this->model->getAttributeTranslated($fieldName, $locale);
 
             return $this->renderFieldElement($field);
         }


### PR DESCRIPTION
Current version of plugin results in this error being logged all the time:
RainLab\Translate\Behaviors\TranslatableModel::getTranslateAttribute is deprecated, use getAttributeTranslated instead.

Applying the fix from error removes this problem.